### PR TITLE
Fix battery percent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         file:
           - Integrations/ESPHome/TEMP-1.yaml
           - Integrations/ESPHome/TEMP-1_BLE.yaml
-          - Integrations/ESPHome/AIR-1_Minimal.yaml
+          - Integrations/ESPHome/TEMP-1_Minimal.yaml
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.7

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-temp-1
-  version: "24.8.25.6"
+  version: "24.8.25.7"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -27,6 +27,10 @@ globals:
     restore_value: no
     type: uint32_t
     initial_value: '0'
+  - id: last_temp
+    type: float
+    restore_value: yes
+    initial_value: '0.0'
 
 captive_portal:
 
@@ -60,12 +64,10 @@ deep_sleep:
   sleep_duration: 8h
   run_duration: 30s
 
-# TODO: Add temp difference threshold notification. Sensor wakes up, checks temp difference from last measurement, if greater than threshold, send notification.
-# TODO: Add option to only notify when temp difference is greater than difference threshold.
 
 number:
   - platform: template
-    name: AHT Temperature Offset
+    name: Board Temperature Offset
     id: aht_temperature_offset
     restore_value: true
     initial_value: 0.0
@@ -79,7 +81,7 @@ number:
     mode: box
 
   - platform: template
-    name: AHT Humidity Offset
+    name: Board Humidity Offset
     id: aht_humidity_offset
     restore_value: true
     initial_value: 0
@@ -93,12 +95,12 @@ number:
     mode: box
 
   - platform: template
-    name: Max Temp
+    name: Max Probe Temp
     id: max_temp
     restore_value: true
-    initial_value: 0
-    min_value: -70.0
-    max_value: 120.0
+    initial_value: 125.0
+    min_value: -55.0
+    max_value: 125.0
     entity_category: "CONFIG"
     unit_of_measurement: "°C"
     optimistic: true
@@ -107,12 +109,26 @@ number:
     mode: box
 
   - platform: template
-    name: Min Temp
+    name: Min Probe Temp
     id: min_temp
     restore_value: true
-    initial_value: 0
-    min_value: -70.0
-    max_value: 120.0
+    initial_value: -55.0
+    min_value: -55.0
+    max_value: 125.0
+    entity_category: "CONFIG"
+    unit_of_measurement: "°C"
+    optimistic: true
+    update_interval: never
+    step: 0.1
+    mode: box
+
+  - platform: template
+    name: Probe Temp Difference Threshold
+    id: temp_diff_threshold
+    restore_value: true
+    initial_value: 0.0
+    min_value: -55.0
+    max_value: 125.0
     entity_category: "CONFIG"
     unit_of_measurement: "°C"
     optimistic: true
@@ -178,9 +194,15 @@ binary_sensor:
     on_release:
       then:
         - lambda: |-
-            if (millis() - id(button_press_timestamp) >= 5000) {
+            if (millis() - id(button_press_timestamp) >= 10000) {
               // Remove Wifi
               id(factory_reset_switch).turn_on();
+            }
+            else if (millis() - id(button_press_timestamp) >= 1000) {
+              //Turn Prevent Sleep On
+              id(prevent_sleep).turn_on();
+              //Prevent Sleep
+              id(deep_sleep_1).prevent_deep_sleep();
             }
             else {
               // StatusCheck
@@ -218,9 +240,18 @@ sensor:
   - platform: dallas_temp
     name: "Temperature Probe"
     update_interval: 5s
+    id: temp_probe
+    on_value:
+      if:
+        condition:
+          switch.is_on: alarm_outside_temp_range
+        then:
+          - lambda: |-
+              id(tempRangeCheck).execute();
     
   - platform: aht10
     variant: AHT20
+    id: aht20
     temperature:
       name: "Board Temperature"
       filters:
@@ -306,6 +337,15 @@ switch:
         - lambda: |- 
             id(deep_sleep_1).allow_deep_sleep();
 
+  - platform: template
+    name: Notify Only Outside Temp Difference
+    id: notify_only_outside_temp_difference
+    icon: mdi:thermometer
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    entity_category: "config"
+
+
 
 script:
   - id: statusCheck
@@ -344,4 +384,13 @@ script:
       - delay: 5s
       - light.turn_off: rgb_light
 
-
+  - id: tempRangeCheck
+    then:
+      - if:
+          condition:
+            or:
+              - lambda: 'return id(max_temp)->state < id(temp_probe).state;'
+              - lambda: 'return id(temp_probe).state < id(min_temp)->state;'
+          then:
+            - rtttl.play:
+                rtttl: "return siren:d=8,o=5,b=100:d,e,d,e,d,e,d,e;"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-temp-1
-  version: "24.8.6.6"
+  version: "24.8.25.6"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -238,6 +238,10 @@ sensor:
     battery_level:
       name: Battery level
       id: batt_pct
+      filters:
+        - lambda: |
+            if (x > 100) return 100;
+            else return (x);
 
 light:
   - platform: esp32_rmt_led_strip

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -15,6 +15,7 @@ esphome:
   on_boot:
     priority: 500
     then:
+      - wifi.disable:
       - switch.turn_on: accessory_power
       - lambda: |-
           id(deep_sleep_1).set_run_duration(id(deep_sleep_run_duration).state * 1000);
@@ -28,8 +29,37 @@ esphome:
              - lambda: |- 
                 ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
                 id(deep_sleep_1).prevent_deep_sleep(); 
+
+      - if:
+          condition:
+            switch.is_on: notify_only_outside_temp_difference
+          then:
+            - delay: 2s
+            - if: # Check If Temp Probe Is Outside Threshold
+                condition:
+                  - lambda: |-
+                      return std::abs(id(temp_probe).state - id(last_temp)) > id(temp_diff_threshold)->state;
+                then: # If So Then Turn On Wifi To Update
+                  - logger.log: "Apollo Automation: Outside Temp Change Detected"
+                  - wifi.enable:
+                  - lambda: |-
+                      id(last_temp) = id(temp_probe).state;
+                else: # If Not Then Check OTA And Sleep
+                  - if:
+                      condition:
+                        and:
+                          - binary_sensor.is_off: ota_mode
+                          - switch.is_off: prevent_sleep
+                      then:
+                      - switch.turn_off: accessory_power
+                      - deep_sleep.enter:
+                          id: deep_sleep_1
+          else: # If Set To Always Notify Turn On Wifi
+            - wifi.enable:
+                  
       
   on_shutdown:
+    - light.turn_off: rgb_light
     - switch.turn_off: accessory_power
 
 dashboard_import:
@@ -59,6 +89,7 @@ update:
     source: https://apolloautomation.github.io/TEMP-1/artifact/manifest.json
 
 wifi:
+  id: wifi_1
   on_connect:
     - delay: 5s
     - ble.disable:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,4 @@ Breaks:
 
 Checks:
 - [ ] Documentation Updated
-- [ ] Build Number Incremented In AIR-1.yaml
-- [ ] Build Number Incremented In manifest.json
-- [ ] firmware-factory.bin Updated
+- [ ] Build Number Incremented In Core.yaml


### PR DESCRIPTION
Version: 24.8.25.7

Adds:
- Ability To Alarm On Outside Temp Range
- Ability To Only Turn On Wifi When Temp Changes Significantly
- Ability To Prevent Sleeping By Pressing Boot For 1s After Restart

Fixes:
- Clamp Battery To 100%

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In AIR-1.yaml
- [ ] Build Number Incremented In manifest.json
- [ ] firmware-factory.bin Updated