### PR TITLE
Remove Wifi Disable That Caused Boot Loop

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-temp-1
-  version: "24.8.26.1"
+  version: "24.9.5.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -1,4 +1,3 @@
-
 esphome:
   name: "${name}"
   friendly_name: Apollo TEMP-1
@@ -15,7 +14,6 @@ esphome:
   on_boot:
     priority: 500
     then:
-      - wifi.disable:
       - switch.turn_on: accessory_power
       - lambda: |-
           id(deep_sleep_1).set_run_duration(id(deep_sleep_run_duration).state * 1000);
@@ -34,6 +32,7 @@ esphome:
           condition:
             switch.is_on: notify_only_outside_temp_difference
           then:
+            - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
             - delay: 2s
             - if: # Check If Temp Probe Is Outside Threshold
                 condition:
@@ -54,8 +53,6 @@ esphome:
                       - switch.turn_off: accessory_power
                       - deep_sleep.enter:
                           id: deep_sleep_1
-          else: # If Set To Always Notify Turn On Wifi
-            - wifi.enable:
                   
       
   on_shutdown:


### PR DESCRIPTION
Version: 24.9.5.1

Adds:

Fixes:
- Boot loop on start of new device due to wifi being off

Breaks:



Checks:
- [x] Documentation Updated
- [x] Build Number Incremented In Core.yaml