### PR TITLE
Add "Sleep After Connecting" and "OTA Helper" to better manage sleep

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-temp-1
-  version: "24.9.5.1"
+  version: "24.9.21.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -17,6 +17,27 @@ api:
         - rtttl.play:
             rtttl: !lambda 'return song_str;'
   reboot_timeout: 0s
+  on_client_connected:
+    then:
+      - delay: 5s
+      - if:
+          condition:
+            or:
+              - binary_sensor.is_on: ota_mode
+              - switch.is_on: prevent_sleep
+          then:
+            - lambda: |- 
+                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA Or Switch");
+                id(deep_sleep_1).prevent_deep_sleep(); 
+          else: 
+            - if:
+                condition:
+                  switch.is_on: sleep_after_connecting
+                then:
+                  - switch.turn_off: accessory_power
+                  - deep_sleep.enter:
+                      id: deep_sleep_1
+
 
 globals:
   - id: cycleCounter
@@ -216,10 +237,14 @@ binary_sensor:
       then:
         - lambda: |- 
             id(deep_sleep_1).prevent_deep_sleep();
-    on_release:
+    on_release:  
       then:
-        - lambda: |- 
-            id(deep_sleep_1).allow_deep_sleep();
+        - if:
+            condition:
+              switch.is_off: prevent_sleep
+            then:
+              - lambda: |- 
+                  id(deep_sleep_1).allow_deep_sleep();
 
 sensor:
   - platform: internal_temperature
@@ -334,8 +359,18 @@ switch:
             id(deep_sleep_1).prevent_deep_sleep();
     on_turn_off:
       then:
-        - lambda: |- 
-            id(deep_sleep_1).allow_deep_sleep();
+        - if:
+            condition:
+              binary_sensor.is_off: ota_mode
+            then:
+              - lambda: |- 
+                  id(deep_sleep_1).allow_deep_sleep();
+  - platform: template
+    name: "Sleep After Connecting"
+    id: sleep_after_connecting
+    icon: mdi:sleep
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
 
   - platform: template
     name: Notify Only Outside Temp Difference

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -54,7 +54,6 @@ esphome:
                       - deep_sleep.enter:
                           id: deep_sleep_1
                   
-      
   on_shutdown:
     - light.turn_off: rgb_light
     - switch.turn_off: accessory_power

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -21,7 +21,7 @@ esphome:
 
 
 dashboard_import:
-  package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1.yaml
+  package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_BLE.yaml
   import_full_config: false
 
 ota:

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -21,7 +21,7 @@ esphome:
 
 
 dashboard_import:
-  package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1.yaml
+  package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml
   import_full_config: false
 
 ota:


### PR DESCRIPTION
Version: 24.9.21.1

Adds:

- "Sleep after connecting" entity. If on, the device will go back to sleep once it has connected to HA for 5 seconds. Even if the full "Run Duration" hasn't completed.
- Adds ability to create a "ota_mode" helper in HA. This will keep the device awake

Fixes:

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml