### PR TITLE
Fix ESPIDF On Beta Boards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - Integrations/ESPHome/TEMP-1_Beta.yaml
           - Integrations/ESPHome/TEMP-1_Minimal.yaml
           - Integrations/ESPHome/TEMP-1B_Minimal.yaml
+          - Integrations/ESPHome/TEMP-1_Beta.yaml
 
           - Integrations/ESPHome/TEMP-1_R2.yaml
           - Integrations/ESPHome/TEMP-1B_R2.yaml

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-temp-1_beta
-  version: "25.1.23.1"
+  version: "25.2.23.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esphome:


### PR DESCRIPTION
Version: 25.2.22.1

Adds:

Fixes:
- Fixes ESPIDF Build On Beta Boards

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml