### PR TITLE
Use IDF 5

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,12 +1,13 @@
 substitutions:
-  version: "25.3.5.1"
+  version: "25.6.9.1"
 
 esp32:
   board: esp32-c3-devkitm-1
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0   
+    advanced:
+      assertion_level: SILENT
+      enable_lwip_assert: false
 
 api:
   services:
@@ -346,7 +347,6 @@ light:
     id: rgb_light
     name: "RGB Light"
     pin: GPIO3
-    rmt_channel: 0
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 1

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     - priority: 800
       then:

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1B"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     - priority: 500
       then:

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1BBLE"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 800
     then:

--- a/Integrations/ESPHome/TEMP-1B_BLE_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE_R2.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "Apollo.TEMP-1BBLE_R2"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 800
     then:

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1B_Minimal"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1B_Minimal_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal_R2.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "Apollo.TEMP-1B_Minimal_R2"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1B_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1B_R2.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "Apollo.TEMP-1B_R2"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     - priority: 500
       then:

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1BLE"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 800
     then:

--- a/Integrations/ESPHome/TEMP-1_BLE_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE_R2.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "Apollo.TEMP-1BLE_R2"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 800
     then:

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -400,7 +400,6 @@ light:
     id: rgb_light
     name: "RGB Light"
     pin: GPIO3
-    rmt_channel: 0
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 1

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -100,8 +100,9 @@ esp32:
   board: esp32-c3-devkitm-1
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0   
+    advanced:
+      assertion_level: SILENT
+      enable_lwip_assert: false
 
 api:
   services:

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -15,7 +15,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1_Beta"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1_Minimal"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 800
     then:

--- a/Integrations/ESPHome/TEMP-1_Minimal_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal_R2.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "Apollo.TEMP-1_Minimal_R2"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     priority: 800
     then:

--- a/Integrations/ESPHome/TEMP-1_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1_R2.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "Apollo.TEMP-1_R2"
     version: "${version}"
 
-  min_version: 2024.2.0
+  min_version: 2025.6.0
   on_boot:
     - priority: 800
       then:


### PR DESCRIPTION
We've done quite a bit of optimization over the last couple of weeks aimed at reducing the size of the compiled binary. With these optimizations, it's now possible to use IDF 5 on the TEMP-1.

Following the June release of ESPHome, this PR can safely be merged & devices updated accordingly.

Version: 25.6.9.1

Adds: IDF 5 support

Fixes:

Breaks:



Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In Core.yaml