### PR TITLE
feat: Enable fine-grained sleep duration control

### DIFF
--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -27,7 +27,7 @@ number:
     id: deep_sleep_sleep_duration
     min_value: 0
     max_value: 800
-    step: 1
+    step: 0.01
     mode: box
     update_interval: never
     optimistic: true


### PR DESCRIPTION
## Summary
- Changes sleep duration step from 1 to 0.01 for TEMP-1B (battery variant)

## Changes
- `Battery.yaml`: step 1 → 0.01 (hours)

## Test plan
- [ ] Flash to TEMP-1B, verify Sleep Duration accepts decimal values (e.g., 1.5, 2.25)
- [ ] Confirm deep sleep activates at the specified duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)