### PR TITLE
[wifi_info] Add IP address text sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -491,7 +491,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
-      id: wifi_ip
+      entity_category: "diagnostic"
 
 script:
   - id: configureSourceSensorPolling

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -494,6 +494,17 @@ text_sensor:
       name: "IP Address"
       id: wifi_ip
       entity_category: "diagnostic"
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    update_interval: never
+    entity_category: "diagnostic"
 
 script:
   - id: configureSourceSensorPolling

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -491,6 +491,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      id: wifi_ip
       entity_category: "diagnostic"
 
 script:


### PR DESCRIPTION
Version: 26.01.18.1

## What does this implement/fix?

Adds the device's current IP address as a diagnostic text sensor in Home Assistant.

This makes it easy to identify and connect to individual TEMP-1/TEMP-1B devices on the network without having to check the router.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IP address sensor to monitor device network connectivity.

* **Improvements**
  * Sensor polling now automatically suspends/resumes based on configuration state and logs actions.

* **Removed**
  * Diagnostic/version sensors (device firmware/version reporting) are no longer exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->