### PR TITLE
[version] Add ESPHome and Apollo firmware version sensors

### DIFF
--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -51,3 +51,4 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: max_17048
+      - component.update: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -496,7 +496,6 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
-    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -496,6 +496,7 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -492,6 +492,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 script:
   - id: configureSourceSensorPolling

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -502,6 +502,7 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -487,6 +487,12 @@ switch:
     disabled_by_default: true
 
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 script:
   - id: configureSourceSensorPolling
     then:

--- a/Integrations/ESPHome/NonBattery.yaml
+++ b/Integrations/ESPHome/NonBattery.yaml
@@ -32,3 +32,4 @@ script:
       - component.update: wifi_signal_db
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
+      - component.update: apollo_firmware_version


### PR DESCRIPTION
Version: 26.01.18.1

## What does this implement/fix?

Adds two diagnostic text sensors to Home Assistant:

- **ESPHome Version** — shows the running ESPHome version (timestamp hidden)
- **Apollo Firmware Version** — shows the Apollo firmware version string from the `version` substitution

Both sensors have `entity_category: diagnostic` so they appear in the device diagnostics panel rather than the main dashboard.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page