### PR TITLE
[esphome] Modernise board spec, web server v3, remove legacy options

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -16,8 +16,8 @@ esphome:
       - script.execute: configureSourceSensorPolling
 
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -492,6 +492,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 script:
   - id: configureSourceSensorPolling

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -487,6 +487,12 @@ switch:
     disabled_by_default: true
 
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 script:
   - id: configureSourceSensorPolling
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -2,7 +2,8 @@ substitutions:
   version: "26.01.18.1"
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  flash_size: 4MB
   framework:
     type: esp-idf
     advanced:

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -7,9 +7,6 @@ esphome:
   friendly_name: Apollo TEMP-1
   comment: Apollo TEMP-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1"
     version: "${version}"
@@ -107,7 +104,8 @@ safe_mode:
 
 web_server:
   port: 80
-  
+  version: 3
+
 update:
   - platform: http_request
     id: firmware_update
@@ -116,11 +114,6 @@ update:
 
 wifi:
   id: wifi_1
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo TEMP1 Hotspot"
 

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -7,9 +7,6 @@ esphome:
   friendly_name: Apollo TEMP-1B
   comment: Apollo TEMP-1B
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1B"
     version: "${version}"
@@ -107,7 +104,8 @@ safe_mode:
 
 web_server:
   port: 80
-  
+  version: 3
+
 update:
   - platform: http_request
     id: firmware_update
@@ -116,11 +114,6 @@ update:
 
 wifi:
   id: wifi_1
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo TEMP1B Hotspot"
 

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -6,9 +6,6 @@ esphome:
   friendly_name: Apollo TEMP-1BBLE
   comment: Apollo TEMP-1BBLE
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1BBLE"
     version: "${version}"

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -6,9 +6,6 @@ esphome:
   friendly_name: Apollo TEMP-1B Minimal
   comment: Apollo TEMP-1B Minimal
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1B_Minimal"
     version: "${version}"
@@ -88,6 +85,7 @@ ota:
 
 web_server:
   port: 80
+  version: 3
 
 wifi:
   id: wifi_1

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -6,9 +6,6 @@ esphome:
   friendly_name: Apollo TEMP-1BLE
   comment: Apollo TEMP-1BLE
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1BLE"
     version: "${version}"

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -8,9 +8,6 @@ esphome:
   friendly_name: Apollo TEMP-1_Beta
   comment: Apollo TEMP-1_Beta
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1_Beta"
     version: "${version}"
@@ -86,18 +83,14 @@ safe_mode:
 
 wifi:
   id: wifi_1
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo TEMP1 Hotspot"
 
 logger:
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  flash_size: 4MB
   framework:
     type: esp-idf
     advanced:
@@ -105,8 +98,8 @@ esp32:
       enable_lwip_assert: false
 
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:
@@ -153,6 +146,7 @@ captive_portal:
 
 web_server:
   port: 80
+  version: 3
 
 external_components:
   - source: github://ApolloAutomation/esphome-battery-component

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -6,9 +6,6 @@ esphome:
   friendly_name: Apollo TEMP-1 Minimal
   comment: Apollo TEMP-1 Minimal
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.TEMP-1_Minimal"
     version: "${version}"
@@ -88,6 +85,7 @@ safe_mode:
 
 web_server:
   port: 80
+  version: 3
 
 wifi:
   id: wifi_1


### PR DESCRIPTION
## Summary

- Replace `esp32: board: esp32-c3-devkitm-1` with `variant: esp32c3` + `flash_size: 4MB` in Core.yaml and TEMP-1_Beta.yaml
- Remove `platformio_options: board_build.flash_mode: dio` from all 7 device YAMLs (not needed when using variant spec)
- Add `version: 3` to `web_server:` in TEMP-1.yaml, TEMP-1B.yaml, TEMP-1_Minimal.yaml, TEMP-1B_Minimal.yaml, TEMP-1_Beta.yaml
- Remove legacy BLE wifi hooks (`on_connect: ble.disable` / `on_disconnect: ble.enable`) from TEMP-1.yaml, TEMP-1B.yaml, TEMP-1_Beta.yaml
- Update `api: services:` → `actions:` in TEMP-1_Beta.yaml (standalone config, not covered by the separate breaking-change PR)

R2 variants inherit all changes via `packages: !include` and need no direct edits.

## Test plan

- [ ] `esphome config` validates cleanly for TEMP-1.yaml, TEMP-1B.yaml, TEMP-1_Minimal.yaml, TEMP-1B_Minimal.yaml, TEMP-1_BLE.yaml, TEMP-1B_BLE.yaml, TEMP-1_Beta.yaml
- [ ] OTA flash succeeds on a TEMP-1 device
- [ ] OTA flash succeeds on a TEMP-1B device
- [ ] Web server UI loads at device IP

## Type of change

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes