### PR TITLE
Fix Apollo Firmware Version sensor showing unknown

### DIFF
--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -51,4 +51,6 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: max_17048
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"

--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -51,6 +51,3 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: max_17048
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -501,8 +501,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -503,7 +503,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/NonBattery.yaml
+++ b/Integrations/ESPHome/NonBattery.yaml
@@ -32,6 +32,3 @@ script:
       - component.update: wifi_signal_db
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"

--- a/Integrations/ESPHome/NonBattery.yaml
+++ b/Integrations/ESPHome/NonBattery.yaml
@@ -32,4 +32,6 @@ script:
       - component.update: wifi_signal_db
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -15,6 +15,9 @@ esphome:
   on_boot:
     - priority: 800
       then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
         - if:

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -15,9 +15,6 @@ esphome:
   on_boot:
     - priority: 800
       then:
-        - text_sensor.template.publish:
-            id: apollo_firmware_version
-            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
         - if:
@@ -73,6 +70,11 @@ esphome:
                         then:
                         - deep_sleep.enter:
                             id: deep_sleep_1
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: -500
       then:
         - switch.turn_on: accessory_power

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -15,6 +15,9 @@ esphome:
   on_boot:
     - priority: 500
       then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
         - if:

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -12,8 +12,11 @@ esphome:
 
   min_version: 2025.11.0
   on_boot:
-    priority: 800
+    priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
       - if:

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -14,6 +14,9 @@ esphome:
   on_boot:
     priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
       - if:

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -12,8 +12,11 @@ esphome:
 
   min_version: 2025.11.0
   on_boot:
-    priority: 800
+    priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
       - if:

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -16,6 +16,9 @@ esphome:
   on_boot:
     priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - switch.turn_on: accessory_power
       - lambda: |-
           id(deep_sleep_1).set_run_duration(id(deep_sleep_run_duration).state * 1000);

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -12,8 +12,11 @@ esphome:
 
   min_version: 2025.11.0
   on_boot:
-    priority: 800
+    priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
       - if:


### PR DESCRIPTION
Version:

## What does this implement/fix?

Fixes Apollo Firmware Version text sensor showing "unknown" in Home Assistant.

- Replaced `component.update` with `text_sensor.template.publish` for the version sensor in `reportAllValues` script (Battery.yaml and NonBattery.yaml)
- Removed `update_interval: never` so the lambda also fires periodically (every 60s) as a fallback

The root cause is that ESPHome's `component.update` action silently skips execution when the component's `is_ready()` check fails (see `UpdateComponentAction::play()` in `esphome/core/base_automation.h`). The `text_sensor.template.publish` action calls `publish_state()` directly without this guard.

Same fix as ApolloAutomation/AIR-1#87

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apollo firmware version detection and display by updating the update mechanism for more reliable version information retrieval across different device configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->