### PR TITLE
fix: RGB LED stays on during deep sleep

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -43,6 +43,8 @@ api:
             - lambda: |-
                 id(reportAllValues).execute();
             - delay: 5s
+            - light.turn_off: rgb_light
+            - delay: 50ms
             - deep_sleep.enter:
                 id: deep_sleep_1
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -43,8 +43,10 @@ api:
             - lambda: |-
                 id(reportAllValues).execute();
             - delay: 5s
-            - light.turn_off: rgb_light
-            - delay: 50ms
+            - light.turn_off:
+                id: rgb_light
+                transition_length: 0ms
+            - delay: 200ms
             - deep_sleep.enter:
                 id: deep_sleep_1
 

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -89,7 +89,10 @@ esphome:
               - delay: 10s
               - lambda: "id(testScript).execute();"
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
+    - switch.turn_off: accessory_power
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -68,8 +68,10 @@ esphome:
                             - binary_sensor.is_off: ota_mode
                             - switch.is_off: prevent_sleep
                         then:
-                        - light.turn_off: rgb_light
-                        - delay: 50ms
+                        - light.turn_off:
+                            id: rgb_light
+                            transition_length: 0ms
+                        - delay: 200ms
                         - deep_sleep.enter:
                             id: deep_sleep_1
     - priority: 500
@@ -87,9 +89,7 @@ esphome:
               - delay: 10s
               - lambda: "id(testScript).execute();"
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -85,7 +85,9 @@ esphome:
               - delay: 10s
               - lambda: "id(testScript).execute();"
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -68,6 +68,8 @@ esphome:
                             - binary_sensor.is_off: ota_mode
                             - switch.is_off: prevent_sleep
                         then:
+                        - light.turn_off: rgb_light
+                        - delay: 50ms
                         - deep_sleep.enter:
                             id: deep_sleep_1
     - priority: 500

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -71,8 +71,10 @@ esphome:
                             - binary_sensor.is_off: ota_mode
                             - switch.is_off: prevent_sleep
                         then:
-                        - light.turn_off: rgb_light
-                        - delay: 50ms
+                        - light.turn_off:
+                            id: rgb_light
+                            transition_length: 0ms
+                        - delay: 200ms
                         - deep_sleep.enter:
                             id: deep_sleep_1
     - priority: -300
@@ -85,9 +87,7 @@ esphome:
               - lambda: "id(testScript).execute();"
                   
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -83,7 +83,9 @@ esphome:
               - lambda: "id(testScript).execute();"
                   
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -71,6 +71,8 @@ esphome:
                             - binary_sensor.is_off: ota_mode
                             - switch.is_off: prevent_sleep
                         then:
+                        - light.turn_off: rgb_light
+                        - delay: 50ms
                         - deep_sleep.enter:
                             id: deep_sleep_1
     - priority: -300

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -87,7 +87,10 @@ esphome:
               - lambda: "id(testScript).execute();"
                   
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
+    - switch.turn_off: accessory_power
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -79,7 +79,10 @@ esphome:
 
 
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
+    - switch.turn_off: accessory_power
 
 logger:
 

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -70,6 +70,8 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
+                      - light.turn_off: rgb_light
+                      - delay: 50ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
                   

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -75,7 +75,9 @@ esphome:
                   
       
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
 
 logger:
 

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -70,16 +70,16 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
-                      - light.turn_off: rgb_light
-                      - delay: 50ms
+                      - light.turn_off:
+                          id: rgb_light
+                          transition_length: 0ms
+                      - delay: 200ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
-                  
-      
+
+
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
 
 logger:
 

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -70,15 +70,15 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
-                      - light.turn_off: rgb_light
-                      - delay: 50ms
+                      - light.turn_off:
+                          id: rgb_light
+                          transition_length: 0ms
+                      - delay: 200ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
-                  
+
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -74,7 +74,9 @@ esphome:
                           id: deep_sleep_1
                   
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -78,7 +78,10 @@ esphome:
                           id: deep_sleep_1
 
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
+    - switch.turn_off: accessory_power
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -70,6 +70,8 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
+                      - light.turn_off: rgb_light
+                      - delay: 50ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
                   

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -78,7 +78,10 @@ esphome:
                           id: deep_sleep_1
 
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
+    - switch.turn_off: accessory_power
 
 logger:
 

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -70,6 +70,8 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
+                      - light.turn_off: rgb_light
+                      - delay: 50ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
       

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -70,15 +70,15 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
-                      - light.turn_off: rgb_light
-                      - delay: 50ms
+                      - light.turn_off:
+                          id: rgb_light
+                          transition_length: 0ms
+                      - delay: 200ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
-      
+
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
 
 logger:
 

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -74,7 +74,9 @@ esphome:
                           id: deep_sleep_1
       
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
 
 logger:
 

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -55,16 +55,16 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
-                      - light.turn_off: rgb_light
-                      - delay: 50ms
+                      - light.turn_off:
+                          id: rgb_light
+                          transition_length: 0ms
+                      - delay: 200ms
                       - switch.turn_off: accessory_power
                       - deep_sleep.enter:
                           id: deep_sleep_1
 
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
     - switch.turn_off: accessory_power
 
 dashboard_import:
@@ -130,8 +130,10 @@ api:
                 condition:
                   switch.is_on: sleep_after_connecting
                 then:
-                  - light.turn_off: rgb_light
-                  - delay: 50ms
+                  - light.turn_off:
+                      id: rgb_light
+                      transition_length: 0ms
+                  - delay: 200ms
                   - switch.turn_off: accessory_power
                   - deep_sleep.enter:
                       id: deep_sleep_1

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -64,7 +64,9 @@ esphome:
                           id: deep_sleep_1
 
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
     - switch.turn_off: accessory_power
 
 dashboard_import:

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -55,10 +55,12 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
+                      - light.turn_off: rgb_light
+                      - delay: 50ms
                       - switch.turn_off: accessory_power
                       - deep_sleep.enter:
                           id: deep_sleep_1
-                  
+
   on_shutdown:
     - light.turn_off:
         id: rgb_light
@@ -128,6 +130,8 @@ api:
                 condition:
                   switch.is_on: sleep_after_connecting
                 then:
+                  - light.turn_off: rgb_light
+                  - delay: 50ms
                   - switch.turn_off: accessory_power
                   - deep_sleep.enter:
                       id: deep_sleep_1

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -60,7 +60,9 @@ esphome:
                           id: deep_sleep_1
                   
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
     - switch.turn_off: accessory_power
 
 dashboard_import:

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -78,7 +78,10 @@ esphome:
                           id: deep_sleep_1
                   
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
+    - switch.turn_off: accessory_power
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -74,7 +74,9 @@ esphome:
                           id: deep_sleep_1
                   
   on_shutdown:
-    - light.turn_off: rgb_light
+    - light.turn_off:
+        id: rgb_light
+        transition_length: 0ms
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -70,6 +70,8 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
+                      - light.turn_off: rgb_light
+                      - delay: 50ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
                   

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -70,15 +70,15 @@ esphome:
                           - binary_sensor.is_off: ota_mode
                           - switch.is_off: prevent_sleep
                       then:
-                      - light.turn_off: rgb_light
-                      - delay: 50ms
+                      - light.turn_off:
+                          id: rgb_light
+                          transition_length: 0ms
+                      - delay: 200ms
                       - deep_sleep.enter:
                           id: deep_sleep_1
                   
   on_shutdown:
-    - light.turn_off:
-        id: rgb_light
-        transition_length: 0ms
+    - light.turn_off: rgb_light
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/TEMP-1/Integrations/ESPHome/TEMP-1_Minimal.yaml


### PR DESCRIPTION
## Summary
- The WS2812 RGB LED was staying faintly on after entering deep sleep despite `on_shutdown` containing `light.turn_off: rgb_light`
- Root cause: addressable lights (RMT-based) schedule their state update for the *next main loop iteration*, but the loop stops running during shutdown before the signal is transmitted to the LED
- Fix: explicitly specify `transition_length: 0ms` on all `light.turn_off` calls in `on_shutdown` hooks — this bypasses the loop-based timing mechanism so the off command is sent immediately

Confirmed fix per ESPHome issue [#6800](https://github.com/esphome/issues/issues/6800).

## Files changed
All 7 YAML variants updated: `TEMP-1`, `TEMP-1B`, `TEMP-1_Minimal`, `TEMP-1B_Minimal`, `TEMP-1_BLE`, `TEMP-1B_BLE`, `TEMP-1_Beta`

## Test plan
- [ ] Flash device
- [ ] Turn RGB LED on via Home Assistant
- [ ] Wait for device to enter deep sleep
- [ ] Confirm LED turns fully off with no faint glow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized explicit immediate RGB light shutdown (zero transition) during shutdown and sleep paths.
  * Added accessory power switch-off in shutdown sequences where applicable.

* **Bug Fixes**
  * Inserted an explicit light-off followed by a 200ms delay before deep sleep and after client disconnects to ensure LEDs extinguish reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->