### PR TITLE
Fix firmware update entity being stale for 6h after boot

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -41,11 +42,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/TEMP-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -118,6 +118,8 @@ update:
     source: ${firmware_update_manifest_url}
 
 wifi:
+  on_connect:
+    - component.update: firmware_update
   id: wifi_1
   ap:
     ssid: "Apollo TEMP1 Hotspot"

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -116,6 +116,8 @@ update:
     source: ${firmware_update_manifest_url}
 
 wifi:
+  on_connect:
+    - component.update: firmware_update
   id: wifi_1
   ap:
     ssid: "Apollo TEMP1B Hotspot"


### PR DESCRIPTION
The `update: http_request` component polls the manifest every 6 hours, and its first poll fires during boot **before the network is up**. When that happens it logs \"Network not connected, skipping update check\" and silently waits for the next 6-hour tick — so for ~6 hours after every boot/power cycle the Firmware Update entity shows stale information even when an update is published.

This adds a manifest check triggered the moment the network connects, making the entity accurate within seconds of boot. The 6-hour poll remains the steady-state cadence.

Found and verified on physical hardware while porting this update system to MTR-1 (the fix is included in the MTR-1/AIR-1/MSR-1/MSR-2 ports).

Note: TEMP-1B is battery/sleep-oriented — the check adds one small HTTPS fetch per wake while connected.