### PR TITLE
Unified firmware: runtime Bluetooth Proxy switch + Stable/Beta channel OTA

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -104,3 +104,14 @@ jobs:
               gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
           done
           echo "Beta assets published."
+
+      - name: Point beta-fw tag at the built commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # gh release create tags default-branch HEAD, and uploads never move
+          # the tag, so without this the release's source commit drifts away
+          # from the assets actually published.
+          gh api -X PATCH "repos/${{ github.repository }}/git/refs/tags/beta-fw" \
+            -f sha="${{ github.sha }}" -F force=true
+          echo "beta-fw -> ${{ github.sha }}"

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,106 @@
+name: Build and Publish Beta
+
+# Builds TEMP-1 firmware from the beta branch and publishes it as assets on a
+# rolling "beta-fw" pre-release. The on-device "Firmware Channel" select points
+# OTA updates at these assets. Stable firmware is built/published separately
+# by build.yml (push to main -> GitHub Pages).
+
+on:
+  push:
+    branches: [beta]
+    paths:
+      - 'Integrations/ESPHome/**'
+  workflow_dispatch:
+
+# Least privilege: read-only by default; only publish-beta is elevated to write.
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Read version
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.read.outputs.v }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - id: read
+        run: |
+          v=$(awk '/substitutions:/ {f=1} f && /version:/ {print $2; exit}' \
+            Integrations/ESPHome/Core.yaml | tr -d '"')
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "Beta version: $v"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: version
+    strategy:
+      matrix:
+        include:
+          # Beta serves OTA updates only, so it builds the end-user Minimal
+          # images, not the first-flash improv images. Artifact names match
+          # the on-device variant_slug: "", "-b", "2", "-b2".
+          - { yaml: Integrations/ESPHome/beta-channel/TEMP-1_Minimal.yaml,     name: firmware-beta }
+          - { yaml: Integrations/ESPHome/beta-channel/TEMP-1B_Minimal.yaml,    name: firmware-b-beta }
+          - { yaml: Integrations/ESPHome/beta-channel/TEMP-1_Minimal_R2.yaml,  name: firmware2-beta }
+          - { yaml: Integrations/ESPHome/beta-channel/TEMP-1B_Minimal_R2.yaml, name: firmware-b2-beta }
+    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
+    with:
+      files: ${{ matrix.yaml }}
+      esphome-version: stable
+      combined-name: ${{ matrix.name }}
+      release-version: ${{ needs.version.outputs.v }}
+
+  publish-beta:
+    name: Publish beta release assets
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: fw
+          pattern: firmware*
+
+      - name: Ensure rolling 'beta-fw' pre-release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view beta-fw -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta-fw -R "${{ github.repository }}" \
+                 --prerelease --title "Beta (rolling)" \
+                 --notes "Latest TEMP-1 beta firmware. Auto-updated on every push to the beta branch."
+
+      - name: Rewrite manifests to absolute URLs and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta-fw"
+          # Manifest names match the on-device variant_slug: "", "-b", "2", "-b2".
+          declare -A DIRS=( [""]=firmware-beta ["-b"]=firmware-b-beta ["2"]=firmware2-beta ["-b2"]=firmware-b2-beta )
+          for v in "" "-b" "2" "-b2"; do
+            src="fw/${DIRS[$v]}"
+            man=$(find "$src" -name manifest.json | head -1)
+            if [ -z "$man" ]; then
+              echo "::error::manifest.json not found for ${DIRS[$v]}"
+              exit 1
+            fi
+            echo "Rewriting $man"
+            # Make ota.path and parts[].path absolute release-asset URLs so the
+            # device never has to resolve a relative path against a redirect.
+            # The four variants have distinct device names, so bin filenames
+            # don't collide in the flat release-asset namespace.
+            jq --arg base "$BASE" '
+              .builds[0].ota.path = ($base + "/" + (.builds[0].ota.path | sub(".*/"; "")))
+              | .builds[0].parts |= map(.path = ($base + "/" + (.path | sub(".*/"; ""))))
+            ' "$man" > "manifest$v.json"
+            cat "manifest$v.json"
+            gh release upload beta-fw "manifest$v.json" -R "${{ github.repository }}" --clobber
+            find "$src" -name '*.bin' -print -exec \
+              gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
+          done
+          echo "Beta assets published."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-and-publish:
-    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@main
+    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@430d90dc695c6f7d1075c4e4a0df4b13a6496252 # main 2026-07-23
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-and-publish:
-    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@430d90dc695c6f7d1075c4e4a0df4b13a6496252 # main 2026-07-23
+    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@main
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,19 @@ jobs:
       pull-requests: write
     with:
       device-name: temp-1
+      # The Minimal yamls are the end-user images served at firmware*/ (OTA
+      # updates and dashboard adoption). The improv images move to *-factory/
+      # and are only used for first flashes via the web installer.
       yaml-files: |
+        Integrations/ESPHome/TEMP-1_Minimal.yaml
+        Integrations/ESPHome/TEMP-1B_Minimal.yaml
+        Integrations/ESPHome/TEMP-1_Minimal_R2.yaml
+        Integrations/ESPHome/TEMP-1B_Minimal_R2.yaml
         Integrations/ESPHome/TEMP-1.yaml
         Integrations/ESPHome/TEMP-1B.yaml
         Integrations/ESPHome/TEMP-1_R2.yaml
         Integrations/ESPHome/TEMP-1B_R2.yaml
-      firmware-names: "1:firmware,1B:firmware-b,1_R2:firmware2,1B_R2:firmware-b2"
+      firmware-names: "1_Minimal:firmware,1B_Minimal:firmware-b,1_Minimal_R2:firmware2,1B_Minimal_R2:firmware-b2,1:firmware-factory,1B:firmware-b-factory,1_R2:firmware2-factory,1B_R2:firmware-b2-factory"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/.gitignore
+++ b/Integrations/ESPHome/.gitignore
@@ -3,3 +3,4 @@
 # You can modify this file to suit your needs.
 /.esphome/
 /secrets.yaml
+beta-channel/.esphome/

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,20 @@
 substitutions:
-  version: "26.3.2.1"
+  version: "26.7.12.1"
+  # Firmware variant identity: overridden by the TEMP-1B / R2 images so each
+  # hardware variant tracks its own manifests ("", "-b", "2", "-b2").
+  variant_slug: ""
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
+  # Manifest URL bases. Stable = GitHub Pages (main branch builds).
+  # Beta = rolling "beta-fw" pre-release assets (beta branch builds).
+  stable_manifest_base: "https://apolloautomation.github.io/TEMP-1"
+  beta_manifest_base: "https://github.com/ApolloAutomation/TEMP-1/releases/download/beta-fw"
+  # Per-variant OTA manifest URLs picked by apply_ota_source.
+  ota_stable_manifest: "${stable_manifest_base}/firmware${variant_slug}/manifest.json"
+  ota_beta_manifest: "${beta_manifest_base}/manifest${variant_slug}.json"
 
 esp32:
   variant: esp32c3
@@ -10,11 +25,36 @@ esp32:
       assertion_level: SILENT
       enable_lwip_assert: false
 
+esp32_ble_tracker:
+  id: ble_tracker
+  scan_parameters:
+    continuous: true
+
+bluetooth_proxy:
+
 esphome:
+  # List form so package merging concatenates with each variant's own on_boot
+  # entries (mapping form would be replaced by the variant's block instead).
   on_boot:
-    priority: 500
-    then:
-      - script.execute: configureSourceSensorPolling
+    - priority: 500
+      then:
+        - script.execute: configureSourceSensorPolling
+    # Point the update entity at the selected channel's manifest.
+    - priority: -100
+      then:
+        - script.execute: apply_ota_source
+    # Re-apply the Bluetooth Proxy switch after all components set up, so BLE
+    # scanning matches the persisted switch (proxy stays off by default).
+    - priority: -300
+      then:
+        - if:
+            condition:
+              switch.is_on: bluetooth_proxy_switch
+            then:
+              - esp32_ble_tracker.start_scan:
+                  continuous: true
+            else:
+              - esp32_ble_tracker.stop_scan:
 
 api:
   actions:
@@ -73,6 +113,17 @@ globals:
     initial_value: "false"
 
 captive_portal:
+
+http_request:
+  verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
 
 
 i2c:
@@ -404,6 +455,34 @@ button:
     icon: mdi:power-cycle
     name: "ESP Reboot"
 
+  - platform: template
+    name: "Firmware Update"
+    id: update_firmware
+    icon: mdi:cloud-download
+    entity_category: "config"
+    on_press:
+      - logger.log: "Applying firmware update for the selected channel"
+      # OTA download needs the device awake for its whole duration.
+      - lambda: |-
+          id(deep_sleep_1).prevent_deep_sleep();
+      - delay: 3s
+      - script.execute: apply_ota_source
+      - script.wait: apply_ota_source
+      # The manifest fetch runs in its own task; give it a fixed window to land
+      # (update.is_available stays false for same-version switches).
+      - delay: 5s
+      - lambda: id(update_http_request).perform(true);
+      # Only reached if the update did not start (e.g. manifest unreachable).
+      # Re-arm deep sleep unless something else is holding the device awake.
+      - if:
+          condition:
+            and:
+              - switch.is_off: prevent_sleep
+              - binary_sensor.is_off: ota_mode
+          then:
+            - lambda: |-
+                id(deep_sleep_1).allow_deep_sleep();
+
   - platform: factory_reset
     disabled_by_default: True
     name: "Factory Reset ESP"
@@ -411,6 +490,21 @@ button:
 
 
 select:
+  - platform: template
+    name: "Firmware Channel"
+    id: firmware_channel
+    icon: mdi:source-branch
+    entity_category: "config"
+    optimistic: true
+    restore_value: true
+    options:
+      - "Stable"
+      - "Beta"
+    initial_option: "${firmware_channel_default}"
+    on_value:
+      then:
+        - script.execute: apply_ota_source
+
   - platform: template
     name: "Select Probe"
     optimistic: true
@@ -487,6 +581,21 @@ switch:
     entity_category: "config"
     disabled_by_default: true
 
+  # Note: on this deep-sleep device the proxy only forwards while the device
+  # is awake - pair it with "Prevent Sleep" to use it continuously.
+  - platform: template
+    name: "Bluetooth Proxy"
+    id: bluetooth_proxy_switch
+    icon: mdi:bluetooth
+    entity_category: "config"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - esp32_ble_tracker.start_scan:
+          continuous: true
+    on_turn_off:
+      - esp32_ble_tracker.stop_scan:
+
 
 text_sensor:
   - platform: wifi_info
@@ -505,6 +614,18 @@ text_sensor:
     entity_category: "diagnostic"
 
 script:
+  - id: apply_ota_source
+    # Sets the OTA manifest URL from the Firmware Channel select (Stable/Beta).
+    # The manifest URLs are per-variant (ota_*_manifest substitutions via
+    # ${variant_slug}) so each hardware variant tracks its own manifests.
+    then:
+      - lambda: |-
+          const bool beta = id(firmware_channel).current_option() == "Beta";
+          std::string url = beta ? "${ota_beta_manifest}" : "${ota_stable_manifest}";
+          ESP_LOGI("firmware", "OTA manifest set to: %s", url.c_str());
+          id(update_http_request).set_source_url(url);
+      - component.update: update_http_request
+
   - id: configureSourceSensorPolling
     then:
       - if:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.7.12.1"
+  version: "26.7.14.1"
   # Firmware variant identity: overridden by the TEMP-1B / R2 images so each
   # hardware variant tracks its own manifests ("", "-b", "2", "-b2").
   variant_slug: ""
@@ -57,6 +57,7 @@ esphome:
               - esp32_ble_tracker.stop_scan:
 
 api:
+  encryption:
   actions:
     - action: play_buzzer
       variables:

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -1,6 +1,7 @@
 substitutions:
   source_sensor_resistance: 100kOhm
-  firmware_update_manifest_url: https://apolloautomation.github.io/TEMP-1/firmware/manifest.json
+  # Firmware variant identity: drives the OTA manifest paths in Core.yaml.
+  variant_slug: ""
 
 esphome:
   name: "apollo-temp-1"
@@ -102,9 +103,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-
 safe_mode:
 
 web_server:
@@ -113,11 +111,13 @@ web_server:
 
 update:
   - platform: http_request
-    id: firmware_update
+    id: update_http_request
     name: Firmware Update
-    source: ${firmware_update_manifest_url}
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   id: wifi_1
   ap:
     ssid: "Apollo TEMP1 Hotspot"

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -1,6 +1,7 @@
 substitutions:
   source_sensor_resistance: 100kOhm
-  firmware_update_manifest_url: https://apolloautomation.github.io/TEMP-1/firmware-b/manifest.json
+  # Firmware variant identity: drives the OTA manifest paths in Core.yaml.
+  variant_slug: "-b"
 
 esphome:
   name: "apollo-temp-1b"
@@ -100,9 +101,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-
 safe_mode:
 
 web_server:
@@ -111,11 +109,13 @@ web_server:
 
 update:
   - platform: http_request
-    id: firmware_update
+    id: update_http_request
     name: Firmware Update
-    source: ${firmware_update_manifest_url}
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   id: wifi_1
   ap:
     ssid: "Apollo TEMP1B Hotspot"

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  variant_slug: "-b"
   source_sensor_resistance: 100kOhm
 
 esphome:
@@ -11,69 +12,71 @@ esphome:
     version: "${version}"
 
   min_version: 2025.11.0
+  # List form so package merging concatenates with Core.yaml's on_boot
+  # entries (mapping form would replace Core's whole list instead).
   on_boot:
-    priority: 500
-    then:
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
-      - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
-      - if:
-          condition:
-            or:
-              - binary_sensor.is_on: ota_mode
-              - switch.is_on: prevent_sleep
-          then:
-             - lambda: |- 
-                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+        - lambda: |-
+            id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
+        - if:
+            condition:
+              or:
+                - binary_sensor.is_on: ota_mode
+                - switch.is_on: prevent_sleep
+            then:
+               - lambda: |-
+                  ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
+                  id(deep_sleep_1).prevent_deep_sleep();
 
-      - if:
-          condition:
-            switch.is_on: notify_only_outside_temp_difference
-          then:
-            - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
-            - switch.turn_on: accessory_power
-            - delay: 5s
-            - lambda: |-
-                id(reportAllValues).execute();
-            - delay: 5s          
-            - if: # Check If Temp Probe Is Outside Threshold
-                condition:
-                  - lambda: |-
-                      // Determine the selected probe
-                      auto selected_probe = id(temp_probe_select).current_option();
-                      float current_temp;
+        - if:
+            condition:
+              switch.is_on: notify_only_outside_temp_difference
+            then:
+              - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
+              - switch.turn_on: accessory_power
+              - delay: 5s
+              - lambda: |-
+                  id(reportAllValues).execute();
+              - delay: 5s
+              - if: # Check If Temp Probe Is Outside Threshold
+                  condition:
+                    - lambda: |-
+                        // Determine the selected probe
+                        auto selected_probe = id(temp_probe_select).current_option();
+                        float current_temp;
 
-                      if (selected_probe == "Temperature") {
-                        current_temp = id(temp_probe).state;
-                      } else {
-                        current_temp = id(ntc_sensor).state;
-                      }
+                        if (selected_probe == "Temperature") {
+                          current_temp = id(temp_probe).state;
+                        } else {
+                          current_temp = id(ntc_sensor).state;
+                        }
 
-                      // Check temperature difference
-                      if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
-                        return true;
-                        id(last_temp) = current_temp;
-                      } else {
-                        return false;
-                      }
-                then: # If So Then Turn On Wifi To Update
-                  - logger.log: "Apollo Automation: Outside Temp Change Detected"
-                  - lambda: |-
-                      id(last_temp) = id(temp_probe).state;
-                else: # If Not Then Check OTA And Sleep
-                  - if:
-                      condition:
-                        and:
-                          - binary_sensor.is_off: ota_mode
-                          - switch.is_off: prevent_sleep
-                      then:
-                      - deep_sleep.enter:
-                          id: deep_sleep_1
-                  
-      
+                        // Check temperature difference
+                        if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
+                          return true;
+                          id(last_temp) = current_temp;
+                        } else {
+                          return false;
+                        }
+                  then: # If So Then Turn On Wifi To Update
+                    - logger.log: "Apollo Automation: Outside Temp Change Detected"
+                    - lambda: |-
+                        id(last_temp) = id(temp_probe).state;
+                  else: # If Not Then Check OTA And Sleep
+                    - if:
+                        condition:
+                          and:
+                            - binary_sensor.is_off: ota_mode
+                            - switch.is_off: prevent_sleep
+                        then:
+                        - deep_sleep.enter:
+                            id: deep_sleep_1
+
+
   on_shutdown:
     - light.turn_off: rgb_light
 
@@ -86,18 +89,23 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 safe_mode:
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo TEMP1 Hotspot"
     
-bluetooth_proxy:
-  active: true
-esp32_ble_tracker:
-  scan_parameters:
-    active: false
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/TEMP-1B_BLE_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE_R2.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  variant_slug: "-b2"
   source_sensor_resistance: 3.3kOhm
 
 packages:

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -2,77 +2,79 @@ substitutions:
   source_sensor_resistance: 100kOhm
 
 esphome:
-  name: "apollo-temp-1b-minimal"
-  friendly_name: Apollo TEMP-1B Minimal
-  comment: Apollo TEMP-1B Minimal
+  name: "apollo-temp-1b"
+  friendly_name: Apollo TEMP-1B
+  comment: Apollo TEMP-1B
   name_add_mac_suffix: true
   project:
-    name: "ApolloAutomation.TEMP-1B_Minimal"
+    name: "ApolloAutomation.TEMP-1B"
     version: "${version}"
 
   min_version: 2025.11.0
+  # List form so package merging concatenates with Core.yaml's on_boot
+  # entries (mapping form would replace Core's whole list instead).
   on_boot:
-    priority: 500
-    then:
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
-      - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
-      - if:
-          condition:
-            or:
-              - binary_sensor.is_on: ota_mode
-              - switch.is_on: prevent_sleep
-          then:
-             - lambda: |- 
-                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+        - lambda: |-
+            id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
+        - if:
+            condition:
+              or:
+                - binary_sensor.is_on: ota_mode
+                - switch.is_on: prevent_sleep
+            then:
+               - lambda: |-
+                  ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
+                  id(deep_sleep_1).prevent_deep_sleep();
 
-      - if:
-          condition:
-            switch.is_on: notify_only_outside_temp_difference
-          then:
-            - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
-            - switch.turn_on: accessory_power
-            - delay: 5s
-            - lambda: |-
-                id(reportAllValues).execute();
-            - delay: 5s          
-            - if: # Check If Temp Probe Is Outside Threshold
-                condition:
-                  - lambda: |-
-                      // Determine the selected probe
-                      auto selected_probe = id(temp_probe_select).current_option();
-                      float current_temp;
+        - if:
+            condition:
+              switch.is_on: notify_only_outside_temp_difference
+            then:
+              - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
+              - switch.turn_on: accessory_power
+              - delay: 5s
+              - lambda: |-
+                  id(reportAllValues).execute();
+              - delay: 5s
+              - if: # Check If Temp Probe Is Outside Threshold
+                  condition:
+                    - lambda: |-
+                        // Determine the selected probe
+                        auto selected_probe = id(temp_probe_select).current_option();
+                        float current_temp;
 
-                      if (selected_probe == "Temperature") {
-                        current_temp = id(temp_probe).state;
-                      } else {
-                        current_temp = id(ntc_sensor).state;
-                      }
+                        if (selected_probe == "Temperature") {
+                          current_temp = id(temp_probe).state;
+                        } else {
+                          current_temp = id(ntc_sensor).state;
+                        }
 
-                      // Check temperature difference
-                      if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
-                        return true;
-                        id(last_temp) = current_temp;
-                      } else {
-                        return false;
-                      }
-                then: # If So Then Turn On Wifi To Update
-                  - logger.log: "Apollo Automation: Outside Temp Change Detected"
-                  - lambda: |-
-                      id(last_temp) = id(temp_probe).state;
-                else: # If Not Then Check OTA And Sleep
-                  - if:
-                      condition:
-                        and:
-                          - binary_sensor.is_off: ota_mode
-                          - switch.is_off: prevent_sleep
-                      then:
-                      - deep_sleep.enter:
-                          id: deep_sleep_1
-                  
+                        // Check temperature difference
+                        if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
+                          return true;
+                          id(last_temp) = current_temp;
+                        } else {
+                          return false;
+                        }
+                  then: # If So Then Turn On Wifi To Update
+                    - logger.log: "Apollo Automation: Outside Temp Change Detected"
+                    - lambda: |-
+                        id(last_temp) = id(temp_probe).state;
+                  else: # If Not Then Check OTA And Sleep
+                    - if:
+                        condition:
+                          and:
+                            - binary_sensor.is_off: ota_mode
+                            - switch.is_off: prevent_sleep
+                        then:
+                        - deep_sleep.enter:
+                            id: deep_sleep_1
+
   on_shutdown:
     - light.turn_off: rgb_light
 
@@ -85,12 +87,22 @@ safe_mode:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 web_server:
   port: 80
   version: 3
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   id: wifi_1
   ap:
     ssid: "Apollo TEMP1B Hotspot"

--- a/Integrations/ESPHome/TEMP-1B_Minimal_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal_R2.yaml
@@ -1,13 +1,14 @@
 substitutions:
+  variant_slug: "-b2"
   source_sensor_resistance: 3.3kOhm
 
 packages:
   TEMP_1B_Minimal: !include "TEMP-1B_Minimal.yaml"
 
 esphome:
-  name: "apollo-temp-1bminimalr2"
+  name: "apollo-temp-1b-42"
   project:
-    name: "Apollo.TEMP-1B_Minimal_R2"
+    name: "Apollo.TEMP-1B_R2"
     version: "${version}"
 
 dashboard_import:

--- a/Integrations/ESPHome/TEMP-1B_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1B_R2.yaml
@@ -1,6 +1,6 @@
 substitutions:
   source_sensor_resistance: 3.3kOhm
-  firmware_update_manifest_url: https://apolloautomation.github.io/TEMP-1/firmware-b2/manifest.json
+  variant_slug: "-b2"
 
 packages:
   TEMP_1B: !include "TEMP-1B.yaml"

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -11,68 +11,70 @@ esphome:
     version: "${version}"
 
   min_version: 2025.11.0
+  # List form so package merging concatenates with Core.yaml's on_boot
+  # entries (mapping form would replace Core's whole list instead).
   on_boot:
-    priority: 500
-    then:
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
-      - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
-      - if:
-          condition:
-            or:
-              - binary_sensor.is_on: ota_mode
-              - switch.is_on: prevent_sleep
-          then:
-             - lambda: |- 
-                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+        - lambda: |-
+            id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
+        - if:
+            condition:
+              or:
+                - binary_sensor.is_on: ota_mode
+                - switch.is_on: prevent_sleep
+            then:
+               - lambda: |-
+                  ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
+                  id(deep_sleep_1).prevent_deep_sleep();
 
-      - if:
-          condition:
-            switch.is_on: notify_only_outside_temp_difference
-          then:
-            - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
-            - switch.turn_on: accessory_power
-            - delay: 5s
-            - lambda: |-
-                id(reportAllValues).execute();
-            - delay: 5s          
-            - if: # Check If Temp Probe Is Outside Threshold
-                condition:
-                  - lambda: |-
-                      // Determine the selected probe
-                      auto selected_probe = id(temp_probe_select).current_option();
-                      float current_temp;
+        - if:
+            condition:
+              switch.is_on: notify_only_outside_temp_difference
+            then:
+              - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
+              - switch.turn_on: accessory_power
+              - delay: 5s
+              - lambda: |-
+                  id(reportAllValues).execute();
+              - delay: 5s
+              - if: # Check If Temp Probe Is Outside Threshold
+                  condition:
+                    - lambda: |-
+                        // Determine the selected probe
+                        auto selected_probe = id(temp_probe_select).current_option();
+                        float current_temp;
 
-                      if (selected_probe == "Temperature") {
-                        current_temp = id(temp_probe).state;
-                      } else {
-                        current_temp = id(ntc_sensor).state;
-                      }
+                        if (selected_probe == "Temperature") {
+                          current_temp = id(temp_probe).state;
+                        } else {
+                          current_temp = id(ntc_sensor).state;
+                        }
 
-                      // Check temperature difference
-                      if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
-                        return true;
-                        id(last_temp) = current_temp;
-                      } else {
-                        return false;
-                      }
-                then: # If So Then Turn On Wifi To Update
-                  - logger.log: "Apollo Automation: Outside Temp Change Detected"
-                  - lambda: |-
-                      id(last_temp) = id(temp_probe).state;
-                else: # If Not Then Check OTA And Sleep
-                  - if:
-                      condition:
-                        and:
-                          - binary_sensor.is_off: ota_mode
-                          - switch.is_off: prevent_sleep
-                      then:
-                      - deep_sleep.enter:
-                          id: deep_sleep_1
-      
+                        // Check temperature difference
+                        if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
+                          return true;
+                          id(last_temp) = current_temp;
+                        } else {
+                          return false;
+                        }
+                  then: # If So Then Turn On Wifi To Update
+                    - logger.log: "Apollo Automation: Outside Temp Change Detected"
+                    - lambda: |-
+                        id(last_temp) = id(temp_probe).state;
+                  else: # If Not Then Check OTA And Sleep
+                    - if:
+                        condition:
+                          and:
+                            - binary_sensor.is_off: ota_mode
+                            - switch.is_off: prevent_sleep
+                        then:
+                        - deep_sleep.enter:
+                            id: deep_sleep_1
+
   on_shutdown:
     - light.turn_off: rgb_light
 
@@ -85,18 +87,23 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 safe_mode:
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo TEMP1 Hotspot"
     
-bluetooth_proxy:
-  active: true
-esp32_ble_tracker:
-  scan_parameters:
-    active: false
 packages:
   core: !include Core.yaml
   nonbattery: !include NonBattery.yaml

--- a/Integrations/ESPHome/TEMP-1_BLE_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE_R2.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  variant_slug: "2"
   source_sensor_resistance: 3.3kOhm
 
 packages:

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -2,77 +2,79 @@ substitutions:
   source_sensor_resistance: 100kOhm
 
 esphome:
-  name: "apollo-temp-1-minimal"
-  friendly_name: Apollo TEMP-1 Minimal
-  comment: Apollo TEMP-1 Minimal
+  name: "apollo-temp-1"
+  friendly_name: Apollo TEMP-1
+  comment: Apollo TEMP-1
   name_add_mac_suffix: true
   project:
-    name: "ApolloAutomation.TEMP-1_Minimal"
+    name: "ApolloAutomation.TEMP-1"
     version: "${version}"
 
   min_version: 2025.11.0
+  # List form so package merging concatenates with Core.yaml's on_boot
+  # entries (mapping form would replace Core's whole list instead).
   on_boot:
-    priority: 500
-    then:
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
-      - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
-      - if:
-          condition:
-            or:
-              - binary_sensor.is_on: ota_mode
-              - switch.is_on: prevent_sleep
-          then:
-             - lambda: |- 
-                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+        - lambda: |-
+            id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
+        - if:
+            condition:
+              or:
+                - binary_sensor.is_on: ota_mode
+                - switch.is_on: prevent_sleep
+            then:
+               - lambda: |-
+                  ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
+                  id(deep_sleep_1).prevent_deep_sleep();
 
-      - if:
-          condition:
-            switch.is_on: notify_only_outside_temp_difference
-          then:
-            - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
-            - switch.turn_on: accessory_power
-            - delay: 5s
-            - lambda: |-
-                id(reportAllValues).execute();
-            - delay: 5s          
-            - if: # Check If Temp Probe Is Outside Threshold
-                condition:
-                  - lambda: |-
-                      // Determine the selected probe
-                      auto selected_probe = id(temp_probe_select).current_option();
-                      float current_temp;
+        - if:
+            condition:
+              switch.is_on: notify_only_outside_temp_difference
+            then:
+              - logger.log: "Apollo Automation: Notify Only Outside Temp Difference"
+              - switch.turn_on: accessory_power
+              - delay: 5s
+              - lambda: |-
+                  id(reportAllValues).execute();
+              - delay: 5s
+              - if: # Check If Temp Probe Is Outside Threshold
+                  condition:
+                    - lambda: |-
+                        // Determine the selected probe
+                        auto selected_probe = id(temp_probe_select).current_option();
+                        float current_temp;
 
-                      if (selected_probe == "Temperature") {
-                        current_temp = id(temp_probe).state;
-                      } else {
-                        current_temp = id(ntc_sensor).state;
-                      }
+                        if (selected_probe == "Temperature") {
+                          current_temp = id(temp_probe).state;
+                        } else {
+                          current_temp = id(ntc_sensor).state;
+                        }
 
-                      // Check temperature difference
-                      if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
-                        return true;
-                        id(last_temp) = current_temp;
-                      } else {
-                        return false;
-                      }
-                then: # If So Then Turn On Wifi To Update
-                  - logger.log: "Apollo Automation: Outside Temp Change Detected"
-                  - lambda: |-
-                      id(last_temp) = id(temp_probe).state;
-                else: # If Not Then Check OTA And Sleep
-                  - if:
-                      condition:
-                        and:
-                          - binary_sensor.is_off: ota_mode
-                          - switch.is_off: prevent_sleep
-                      then:
-                      - deep_sleep.enter:
-                          id: deep_sleep_1
-                  
+                        // Check temperature difference
+                        if (std::abs(current_temp - id(last_temp)) > id(temp_diff_threshold)->state) {
+                          return true;
+                          id(last_temp) = current_temp;
+                        } else {
+                          return false;
+                        }
+                  then: # If So Then Turn On Wifi To Update
+                    - logger.log: "Apollo Automation: Outside Temp Change Detected"
+                    - lambda: |-
+                        id(last_temp) = id(temp_probe).state;
+                  else: # If Not Then Check OTA And Sleep
+                    - if:
+                        condition:
+                          and:
+                            - binary_sensor.is_off: ota_mode
+                            - switch.is_off: prevent_sleep
+                        then:
+                        - deep_sleep.enter:
+                            id: deep_sleep_1
+
   on_shutdown:
     - light.turn_off: rgb_light
 
@@ -83,7 +85,15 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
-    
+  - platform: http_request
+    id: ota_managed
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
+
 safe_mode:
 
 web_server:
@@ -91,6 +101,8 @@ web_server:
   version: 3
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   id: wifi_1
   ap:
     ssid: "Apollo TEMP1 Hotspot"

--- a/Integrations/ESPHome/TEMP-1_Minimal_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal_R2.yaml
@@ -1,13 +1,14 @@
 substitutions:
+  variant_slug: "2"
   source_sensor_resistance: 3.3kOhm
 
 packages:
   TEMP_1_Minimal: !include "TEMP-1_Minimal.yaml"
 
 esphome:
-  name: "apollo-temp-1-minimalr2"
+  name: "apollo-temp-1-r2"
   project:
-    name: "Apollo.TEMP-1_Minimal_R2"
+    name: "Apollo.TEMP-1_R2"
     version: "${version}"
 
 dashboard_import:

--- a/Integrations/ESPHome/TEMP-1_R2.yaml
+++ b/Integrations/ESPHome/TEMP-1_R2.yaml
@@ -1,6 +1,6 @@
 substitutions:
   source_sensor_resistance: 3.3kOhm
-  firmware_update_manifest_url: https://apolloautomation.github.io/TEMP-1/firmware2/manifest.json
+  variant_slug: "2"
 
 packages:
   TEMP_1: !include "TEMP-1.yaml"

--- a/Integrations/ESPHome/beta-channel/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/beta-channel/TEMP-1B_Minimal.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of TEMP-1B_Minimal.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use TEMP-1B_Minimal.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../TEMP-1B_Minimal.yaml

--- a/Integrations/ESPHome/beta-channel/TEMP-1B_Minimal_R2.yaml
+++ b/Integrations/ESPHome/beta-channel/TEMP-1B_Minimal_R2.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of TEMP-1B_Minimal_R2.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use TEMP-1B_Minimal_R2.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../TEMP-1B_Minimal_R2.yaml

--- a/Integrations/ESPHome/beta-channel/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/beta-channel/TEMP-1_Minimal.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of TEMP-1_Minimal.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use TEMP-1_Minimal.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../TEMP-1_Minimal.yaml

--- a/Integrations/ESPHome/beta-channel/TEMP-1_Minimal_R2.yaml
+++ b/Integrations/ESPHome/beta-channel/TEMP-1_Minimal_R2.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of TEMP-1_Minimal_R2.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use TEMP-1_Minimal_R2.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../TEMP-1_Minimal_R2.yaml

--- a/static/index.html
+++ b/static/index.html
@@ -98,11 +98,11 @@
     <div class="button-row" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
       <div>
         <p>Non Battery Firmware Revision 1</p>
-        <esp-web-install-button manifest="./firmware/manifest.json"></esp-web-install-button>
+        <esp-web-install-button manifest="./firmware-factory/manifest.json"></esp-web-install-button>
       </div>
       <div>
         <p>Battery Firmware Revision 1</p>
-        <esp-web-install-button manifest="./firmware-b/manifest.json"></esp-web-install-button>
+        <esp-web-install-button manifest="./firmware-b-factory/manifest.json"></esp-web-install-button>
       </div>
     </div>
 
@@ -111,11 +111,11 @@
   <div class="button-row" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
     <div>
       <p>Non Battery Firmware Revision 2</p>
-      <esp-web-install-button manifest="./firmware2/manifest.json"></esp-web-install-button>
+      <esp-web-install-button manifest="./firmware2-factory/manifest.json"></esp-web-install-button>
     </div>
     <div>
       <p>Battery Firmware Revision 2</p>
-      <esp-web-install-button manifest="./firmware-b2/manifest.json"></esp-web-install-button>
+      <esp-web-install-button manifest="./firmware-b2-factory/manifest.json"></esp-web-install-button>
     </div>
   </div>
 


### PR DESCRIPTION
Version: 26.7.12.1

Adds:
- Full port of the unified pattern MSR-1 shipped as 26.7.9.1 (ApolloAutomation/MSR-1#100, ApolloAutomation/MSR-1#103, ApolloAutomation/MSR-1#104), rebuilt from #65. `bluetooth_proxy` + `esp32_ble_tracker` now compile into every image; a "Bluetooth Proxy" switch (default off, persisted, re-applied at boot) starts/stops scanning at runtime. On this deep-sleep device the proxy only forwards while awake — pair it with "Prevent Sleep" for continuous use.
- "Firmware Channel" select (Stable/Beta) + `apply_ota_source`: a direct `set_source_url` swap from per-variant `ota_stable_manifest` / `ota_beta_manifest` substitutions (`${variant_slug}`: "", -b, 2, -b2). The channel is re-applied at boot (`on_boot -100`).
- `http_request` consolidated into Core.yaml with `buffer_size_rx: 5120` / `buffer_size_tx: 2048` — GitHub release redirects overflow the 512-byte defaults (~3.6 KB CSP header line, ~850-char signed query). #65 had no buffer sizing; beta-channel OTA fails without it.
- Publishing flip from #65: Minimal images take over the four Pages `firmware*/` dirs; improv images move to the `*-factory/` dirs; installer page repointed. install.apolloautomation.com needs the matching repoint when this ships to main (mirrors ApolloAutomation/installer#16).
- `beta-channel/` wrappers + build-beta.yml publishing the four per-variant manifests to the rolling `beta-fw` pre-release.

Fixes:
- The `_BLE` build split is retired the MSR-1 way: `_BLE` yamls stay compilable (dashboard_import compat) but lose their own proxy/tracker blocks; their update entities point at the standard manifests — they were never published, so no fielded devices sit on a legacy `firmware-ble` manifest; self-builders converge onto the unified image.
- Core's and the `_BLE`/`_Minimal` variants' `on_boot` converted from mapping to list form so package merging concatenates instead of silently replacing (the AIR-1 merge gotcha).
- No pre-OTA BLE disable in the update button — ESPHome's OTA quiesces BLE itself (MSR-1 #103). The button still holds `prevent_deep_sleep()` and re-arms sleep on the not-started path.

Breaks:
- Nothing fielded: Minimal and `_BLE` images were never published. Sleeping devices only see channel changes/updates while awake — `ota_mode` / "Prevent Sleep" (default ON) governs, unchanged. Note beta's `.github/` is 9 commits behind main (#64 workflow consolidation), so the eventual beta→main sync will need workflow reconciliation — unrelated to this PR's content.

Supersedes #65. Leaves #61 (stale-entity fix) alone.

Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In Core.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Stable/Beta firmware channel selection and over-the-air updates.
  - Added Bluetooth Proxy controls with BLE tracking support.
  - Added firmware update controls that work after Wi‑Fi connection.
  - Added beta-channel firmware configurations for supported device variants.
  - Added Minimal firmware builds for additional device variants.

- **Improvements**
  - Updated firmware version and variant-specific update manifests.
  - Improved installer links for factory firmware images.
  - Added rolling beta firmware releases with downloadable build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->