### PR TITLE
Pin shared reusable workflow to a commit SHA

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -17,4 +17,4 @@ permissions:
 jobs:
   label-check:
     name: Label Check
-    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
+    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@430d90dc695c6f7d1075c4e4a0df4b13a6496252 # main 2026-07-23


### PR DESCRIPTION
Version: 26.3.2.1 (unchanged, workflow only)

## What does this implement/fix?

Pins the `ApolloAutomation/Workflows` label-check reusable workflow reference from the mutable `@main` ref to the current reviewed commit SHA (`430d90dc`, main 2026-07-23), matching how the repo already pins third-party actions. label-check runs on `pull_request_target` with a write token, so a change to the Workflows repo silently changed what runs privileged here.

`build.yml`'s `@main` ref is intentionally left out of this PR; it is pinned by #66 as part of the unified firmware branch refresh.

Trade-off: future Workflows updates need a pin bump in this repo.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
