### PR TITLE
Fix BLE deep-sleep restore using minutes math instead of hours

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.3.2.1"
+  version: "26.7.24.1"
 
 esp32:
   variant: esp32c3

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -18,7 +18,7 @@ esphome:
           id: apollo_firmware_version
           state: "${version}"
       - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
+          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
       - if:
           condition:
             or:


### PR DESCRIPTION
Version: 26.7.24.1

## What does this implement/fix?

`TEMP-1B_BLE.yaml` packages `Battery.yaml`, whose "Sleep Duration" number is in hours (`unit_of_measurement: "h"`, `initial_value: 12`, and the `deep_sleep` default is `12h`). The `on_boot` deep-sleep restore lambda multiplied the stored value by `60 * 1000` (minutes to ms) instead of `60 * 60 * 1000` (hours to ms).

The result: after every reboot the device restored a sleep duration 60x too short, waking roughly every 12 minutes instead of every 12 hours and draining the battery.

The fix changes the expression to `* 60 * 60 * 1000`, matching the correct math already used in `TEMP-1B.yaml`, `TEMP-1B_Minimal.yaml`, and `Battery.yaml`'s own `on_value` handler. The non-battery variants (`TEMP-1.yaml`, `TEMP-1_BLE.yaml`, `TEMP-1_Minimal.yaml`) correctly keep `* 60 * 1000` because `NonBattery.yaml`'s Sleep Duration is in minutes. `TEMP-1B_BLE_R2.yaml` includes `TEMP-1B_BLE.yaml`, so it inherits the fix.

This is a sibling of the same hours-vs-minutes bug found in AIR-1 during the 26.7.23.1 release (ApolloAutomation/AIR-1#119).

Validated with `esphome config` on TEMP-1B_BLE.yaml, TEMP-1B.yaml, and TEMP-1B_BLE_R2.yaml: all report "Configuration is valid!".

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected deep sleep timing so the configured duration is interpreted in hours rather than minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->