### PR TITLE
Replace deprecated rgb_order with channel_colors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.3.2.1"
+  version: "26.8.27.1"
 
 esp32:
   variant: esp32c3

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -384,7 +384,7 @@ light:
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 1
-    rgb_order: grb
+    channel_colors: GRB
     effects:
       - pulse:
           name: "Slow Pulse"

--- a/Integrations/ESPHome/TEMP-1.yaml
+++ b/Integrations/ESPHome/TEMP-1.yaml
@@ -11,7 +11,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     - priority: 800
       then:

--- a/Integrations/ESPHome/TEMP-1B.yaml
+++ b/Integrations/ESPHome/TEMP-1B.yaml
@@ -11,7 +11,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1B"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     - priority: 500
       then:

--- a/Integrations/ESPHome/TEMP-1B_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1B_BLE.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1BBLE"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1B_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1B_Minimal.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1B_Minimal"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1_BLE.yaml
+++ b/Integrations/ESPHome/TEMP-1_BLE.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1BLE"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -12,7 +12,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1_Beta"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -400,7 +400,7 @@ light:
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 1
-    rgb_order: grb
+    channel_colors: GRB
     effects:
       - pulse:
           name: "Slow Pulse"

--- a/Integrations/ESPHome/TEMP-1_Beta.yaml
+++ b/Integrations/ESPHome/TEMP-1_Beta.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-temp-1_beta
-  version: "25.2.23.1"
+  version: "26.8.27.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esphome:

--- a/Integrations/ESPHome/TEMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/TEMP-1_Minimal.yaml
@@ -10,7 +10,7 @@ esphome:
     name: "ApolloAutomation.TEMP-1_Minimal"
     version: "${version}"
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     priority: 500
     then:


### PR DESCRIPTION
ESPHome 2026.8.0 replaces `rgb_order` / `is_rgbw` / `is_wrgb` with a single `channel_colors` key on `esp32_rmt_led_strip` ([esphome#18474](https://github.com/esphome/esphome/pull/18474)).

`channel_colors` takes each of `R`, `G`, `B` exactly once, optionally with a single `W`; the value is case-insensitive. No behaviour change — `grb` and `GRB` are equivalent, uppercase to match the ESPHome docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated ESPHome device configurations to require ESPHome 2026.8.0 or later.
  * Updated Apollo firmware version references across supported configurations.
* **Bug Fixes**
  * Updated RGB LED color-channel configuration for improved compatibility with current ESPHome settings.
  * Applied the LED configuration update across Apollo and TEMP-1 device profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->